### PR TITLE
Wip/cleanup

### DIFF
--- a/_spreferences/PlatformTemplates/models/com.mbeddr.cpp.__spreferences.PlatformTemplates.mps
+++ b/_spreferences/PlatformTemplates/models/com.mbeddr.cpp.__spreferences.PlatformTemplates.mps
@@ -2,7 +2,7 @@
 <model ref="r:7a7d22ce-1d67-4772-b659-fbcc3b235afb(com.mbeddr.cpp.__spreferences.PlatformTemplates)">
   <persistence version="9" />
   <languages>
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
   </languages>
   <imports />
   <registry>
@@ -14,9 +14,10 @@
         <child id="8719112291174072694" name="templates" index="2xbcco" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -39,7 +40,8 @@
         <property role="3r8Kxs" value="make" />
         <property role="2AWWZI" value="-std=c99" />
         <property role="1FkSt$" value="-g" />
-        <property role="18_EFo" value="gcc" />
+        <property role="UXd52" value="g++" />
+        <property role="UXd4T" value="-std=c++11" />
       </node>
     </node>
   </node>

--- a/_spreferences/PlatformTemplates/module.msd
+++ b/_spreferences/PlatformTemplates/module.msd
@@ -13,7 +13,7 @@
   <sourcePath />
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2d7fadf5-33f6-4e80-a78f-0f739add2bde:com.mbeddr.core.buildconfig" version="9" />
+    <language slang="l:2d7fadf5-33f6-4e80-a78f-0f739add2bde:com.mbeddr.core.buildconfig" version="10" />
     <language slang="l:223dd778-c44f-4ef3-9535-7aa7d12244a6:com.mbeddr.core.debug" version="0" />
     <language slang="l:61c69711-ed61-4850-81d9-7714ff227fb0:com.mbeddr.core.expressions" version="5" />
     <language slang="l:f93d1dbe-bfd1-42dd-932a-f375fa6f5373:com.mbeddr.core.make" version="9" />

--- a/languages/com.mbeddr.cpp.modules.gen/models/behavior.mps
+++ b/languages/com.mbeddr.cpp.modules.gen/models/behavior.mps
@@ -923,7 +923,7 @@
             <node concept="2OqwBi" id="ZKpU3BIVHP" role="2Oq$k0">
               <node concept="13iAh5" id="ZKpU3BIVHQ" role="2Oq$k0" />
               <node concept="2qgKlT" id="ZKpU3BIVHR" role="2OqNvi">
-                <ref role="37wK5l" to="qd6m:1H6zsul5X7v" resolve="allFunctionsWithoutInlineHeaderFunctions" />
+                <ref role="37wK5l" to="qd6m:1H6zsul5X7v" resolve="allFunctionsWithoutInlineFunctionsForHeader" />
               </node>
             </node>
             <node concept="3zZkjj" id="ZKpU3BIWLg" role="2OqNvi">

--- a/tests/test.ex.com.mbeddr.cpp/models/Static.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/Static.mps
@@ -20,29 +20,33 @@
     </language>
     <language id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig">
       <concept id="5046689135693761556" name="com.mbeddr.core.buildconfig.structure.Binary" flags="ng" index="2eOfOj">
-        <reference id="2504745233808502246" name="target" index="3oK8_y" />
+        <reference id="2504745233808502246" name="target_old" index="3oK8_y" />
         <child id="5046689135693761559" name="referencedModules" index="2eOfOg" />
+        <child id="5476261277775063442" name="target" index="1kZvWc" />
       </concept>
       <concept id="5046689135693761554" name="com.mbeddr.core.buildconfig.structure.Executable" flags="ng" index="2eOfOl">
         <property id="3431613015799084476" name="isTest" index="iO3LB" />
       </concept>
       <concept id="7717755763392524104" name="com.mbeddr.core.buildconfig.structure.BuildConfiguration" flags="ng" index="2v9HqL">
         <child id="5046689135694070731" name="binaries" index="2ePNbc" />
-        <child id="5323740605968447026" name="target" index="2AWWZH" />
+        <child id="5323740605968447026" name="platform" index="2AWWZH" />
       </concept>
       <concept id="7717755763392524107" name="com.mbeddr.core.buildconfig.structure.ModuleRef" flags="ng" index="2v9HqM">
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
       <concept id="5323740605968447019" name="com.mbeddr.core.buildconfig.structure.Platform" flags="ng" index="2AWWZO">
         <child id="1485382076185232212" name="targets" index="3anu1O" />
       </concept>
-      <concept id="1485382076184236780" name="com.mbeddr.core.buildconfig.structure.Target" flags="ng" index="3abb7c" />
+      <concept id="1485382076184236780" name="com.mbeddr.core.buildconfig.structure.System" flags="ng" index="3abb7c" />
+      <concept id="5476261277774503065" name="com.mbeddr.core.buildconfig.structure.Any" flags="ng" index="1l1$C7" />
       <concept id="2736179788492003936" name="com.mbeddr.core.buildconfig.structure.IDebuggablePlatform" flags="ng" index="1FkSt_">
         <property id="2736179788492003937" name="debugOptions" index="1FkSt$" />
       </concept>
@@ -59,10 +63,10 @@
       </concept>
     </language>
     <language id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base">
-      <concept id="2277423264798216734" name="com.mbeddr.cpp.base.structure.IStaticFlagConcept" flags="ng" index="226hDU">
+      <concept id="2277423264798216734" name="com.mbeddr.cpp.base.structure.IStaticFlag" flags="ng" index="226hDU">
         <property id="2277423264798216735" name="isStatic" index="226hDV" />
       </concept>
-      <concept id="6028541369719415919" name="com.mbeddr.cpp.base.structure.IConstExprFlagConcept" flags="ng" index="OtGC0">
+      <concept id="6028541369719415919" name="com.mbeddr.cpp.base.structure.IConstExprFlag" flags="ng" index="OtGC0">
         <property id="6028541369719415920" name="isConstExpr" index="OtGCv" />
       </concept>
       <concept id="7710120554545509222" name="com.mbeddr.cpp.base.structure.AutoType" flags="ng" index="RSaEH" />
@@ -113,7 +117,7 @@
         <child id="7755897872837031764" name="expected" index="2N2GHh" />
       </concept>
       <concept id="7755897872837082045" name="com.mbeddr.core.unittest.structure.AssertEquals" flags="ng" index="2N2KuS" />
-      <concept id="8610007178384196427" name="com.mbeddr.core.unittest.structure.TestCaseConfigItem" flags="ng" index="12mU2y">
+      <concept id="8610007178384196427" name="com.mbeddr.core.unittest.structure.UnitTestConfigItem" flags="ng" index="12mU2y">
         <child id="842732463503928104" name="testStrategy" index="3GpDut" />
       </concept>
       <concept id="5686538669182340985" name="com.mbeddr.core.unittest.structure.TestCaseRef" flags="ng" index="3cM6IN">
@@ -161,6 +165,9 @@
       <node concept="2v9HqM" id="3v5DuFDttik" role="2eOfOg">
         <ref role="2v9HqP" to="3y0n:1WTn9U1aQF1" resolve="stdio" />
       </node>
+      <node concept="1l1$C7" id="7whd4oRyHDr" role="1kZvWc">
+        <property role="TrG5h" value="any" />
+      </node>
     </node>
     <node concept="2Q9Fgs" id="3v5DuFDtvd1" role="2Q9xDr">
       <node concept="2Q9FjX" id="3v5DuFDtvd2" role="2Q9FjI" />
@@ -174,6 +181,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
       <node concept="3abb7c" id="3v5DuFDkAwk" role="3anu1O">
         <property role="TrG5h" value="Win32" />
       </node>

--- a/tests/test.ex.com.mbeddr.cpp/models/attributes.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/attributes.mps
@@ -29,9 +29,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -273,7 +274,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
 </model>

--- a/tests/test.ex.com.mbeddr.cpp/models/casting.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/casting.mps
@@ -36,9 +36,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -168,7 +169,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
   <node concept="1whW_1" id="4lmr4L5g4z$">

--- a/tests/test.ex.com.mbeddr.cpp/models/chars.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/chars.mps
@@ -31,9 +31,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -142,7 +143,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
   <node concept="1whW_1" id="4ObFW5zjJVX">

--- a/tests/test.ex.com.mbeddr.cpp/models/classes.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/classes.mps
@@ -60,9 +60,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -271,7 +272,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
     <node concept="2eOfOl" id="4o2nsMgBpPF" role="2ePNbc">
       <property role="TrG5h" value="Classes" />

--- a/tests/test.ex.com.mbeddr.cpp/models/constructor.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/constructor.mps
@@ -33,9 +33,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -389,7 +390,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
     <node concept="2eOfOl" id="4o2nsMgBpPF" role="2ePNbc">
       <property role="TrG5h" value="Constructor" />

--- a/tests/test.ex.com.mbeddr.cpp/models/dynamicMemory.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/dynamicMemory.mps
@@ -50,9 +50,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -205,8 +206,9 @@
       <property role="3r8Kw1" value="gdb" />
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
-      <property role="18_EFo" value="gcc" />
       <property role="2AWWZI" value=" " />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
     <node concept="2Q9Fgs" id="6WSa0snB9z3" role="2Q9xDr">
       <node concept="2Q9FjX" id="6WSa0snB9z4" role="2Q9FjI" />

--- a/tests/test.ex.com.mbeddr.cpp/models/methods.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/methods.mps
@@ -29,9 +29,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -155,7 +156,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
   <node concept="1whW_1" id="4lmr4L5g4z$">

--- a/tests/test.ex.com.mbeddr.cpp/models/namespaces.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/namespaces.mps
@@ -51,9 +51,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -834,7 +835,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
 </model>

--- a/tests/test.ex.com.mbeddr.cpp/models/nullPointers.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/nullPointers.mps
@@ -47,9 +47,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -524,7 +525,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
 </model>

--- a/tests/test.ex.com.mbeddr.cpp/models/operatorOverloading.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/operatorOverloading.mps
@@ -36,9 +36,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -819,8 +820,9 @@
       <property role="3r8Kw1" value="gdb" />
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
-      <property role="18_EFo" value="gcc" />
       <property role="2AWWZI" value=" " />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
 </model>

--- a/tests/test.ex.com.mbeddr.cpp/models/specifier.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/specifier.mps
@@ -78,18 +78,9 @@
       <concept id="6028541369715364763" name="com.mbeddr.cpp.base.structure.IVolatileFlagConcept" flags="ng" index="O23RO">
         <property id="6028541369715364764" name="isVolatile" index="O23RN" />
       </concept>
-<<<<<<< HEAD
-<<<<<<< HEAD
       <concept id="6028541369719415919" name="com.mbeddr.cpp.base.structure.IConstExprFlagConcept" flags="ng" index="OtGC0">
         <property id="6028541369719415920" name="isConstExpr" index="OtGCv" />
       </concept>
-=======
->>>>>>> 27c73b6b9d... New and Delete keywords are working, also has executable test and typesystem test
-=======
-      <concept id="6028541369719415919" name="com.mbeddr.cpp.base.structure.IConstExprFlagConcept" flags="ng" index="OtGC0">
-        <property id="6028541369719415920" name="isConstExpr" index="OtGCv" />
-      </concept>
->>>>>>> 8a9c6733aa... Revert "Remove redundant executable testcases"
       <concept id="5044697665789382396" name="com.mbeddr.cpp.base.structure.MethodDeclaration" flags="ng" index="3mB1cK">
         <child id="4185783222026475860" name="body" index="3XIRFX" />
       </concept>
@@ -214,67 +205,29 @@
     <node concept="3mBW2U" id="1Yr26iukrN$" role="N3F5h">
       <property role="2OOxQR" value="false" />
       <property role="TrG5h" value="SomeClass" />
-<<<<<<< HEAD
-<<<<<<< HEAD
-      <node concept="3mBbG7" id="5eDFAXBt0Dc" role="3mBdys">
-        <property role="TrG5h" value="staticField" />
-        <property role="226hDV" value="true" />
-=======
       <node concept="3u$6M4" id="72UYQRXZOKS" role="3mBdys" />
       <node concept="3mBbG7" id="72UYQRXZOVH" role="3mBdys">
->>>>>>> 27c73b6b9d... New and Delete keywords are working, also has executable test and typesystem test
         <property role="1wg9_F" value="public" />
-<<<<<<< HEAD
-        <property role="226hDV" value="true" />
-        <property role="TrG5h" value="staticField" />
-        <node concept="26Vqph" id="72UYQRXZOZ_" role="2C2TGm">
-=======
-=======
       <node concept="3mBbG7" id="5eDFAXBt0Dc" role="3mBdys">
         <property role="TrG5h" value="staticField" />
         <property role="226hDV" value="true" />
         <property role="1wg9_F" value="public" />
->>>>>>> 8a9c6733aa... Revert "Remove redundant executable testcases"
         <property role="OtGCv" value="true" />
         <node concept="3TlMh9" id="6Rfiwa9LP0Z" role="3XIe9v">
           <property role="2hmy$m" value="111" />
         </node>
         <node concept="26Vqph" id="5eDFAXBt0Ga" role="2C2TGm">
-<<<<<<< HEAD
->>>>>>> e6791fc3a8... Cleaned up the executable tests and made sure there weren't snytax errors. Many still have build problems due to UnitTestHelper.h
           <property role="2caQfQ" value="false" />
           <property role="2c7vTL" value="false" />
         </node>
-<<<<<<< HEAD
-        <node concept="3uHhno" id="7j9KGYMPDrF" role="3XIe9v">
-          <ref role="3uHhlH" node="1Yr26iukrNB" resolve="inlinedMethod" />
-=======
         <node concept="3TlMh9" id="72UYQRXZP0d" role="3XIe9v">
           <property role="2hmy$m" value="0" />
->>>>>>> 27c73b6b9d... New and Delete keywords are working, also has executable test and typesystem test
         </node>
       </node>
       <node concept="3u$6M4" id="5eDFAXBt0Ao" role="3mBdys" />
       <node concept="3mBbG7" id="72UYQRXZO_2" role="3mBdys">
         <property role="TrG5h" value="constField" />
         <property role="1wg9_F" value="public" />
-<<<<<<< HEAD
-        <property role="OtGCv" value="true" />
-        <node concept="26Vqph" id="5eDFAXBNIUC" role="2C2TGm">
-=======
-        <node concept="26Vqph" id="72UYQRXZOCN" role="2C2TGm">
->>>>>>> 27c73b6b9d... New and Delete keywords are working, also has executable test and typesystem test
-          <property role="2caQfQ" value="false" />
-          <property role="2c7vTL" value="true" />
-        </node>
-<<<<<<< HEAD
-        <node concept="3TlMh9" id="72UYQRXZODk" role="3XIe9v">
-          <property role="2hmy$m" value="0" />
-=======
-        <node concept="3TlMh9" id="5eDFAXBNIV$" role="3XIe9v">
-          <property role="2hmy$m" value="3" />
->>>>>>> e6791fc3a8... Cleaned up the executable tests and made sure there weren't snytax errors. Many still have build problems due to UnitTestHelper.h
-=======
           <property role="2caQfQ" value="false" />
           <property role="2c7vTL" value="false" />
         </node>
@@ -290,7 +243,6 @@
         </node>
         <node concept="3TlMh9" id="5eDFAXBNIV$" role="3XIe9v">
           <property role="2hmy$m" value="3" />
->>>>>>> 8a9c6733aa... Revert "Remove redundant executable testcases"
         </node>
       </node>
       <node concept="3u$6M4" id="5eDFAXBNIW5" role="3mBdys" />
@@ -306,32 +258,18 @@
           <property role="2hmy$m" value="5" />
         </node>
       </node>
-<<<<<<< HEAD
-      <node concept="3u$6M4" id="72UYQRXZOcq" role="3mBdys" />
-      <node concept="3mBbG7" id="72UYQRXZOjA" role="3mBdys">
-        <property role="TrG5h" value="constVolatileField" />
-<<<<<<< HEAD
-=======
       <node concept="3u$6M4" id="5eDFAXBNJ4o" role="3mBdys" />
       <node concept="3mBbG7" id="5eDFAXBNJ8A" role="3mBdys">
         <property role="TrG5h" value="constVolatileField" />
->>>>>>> 8a9c6733aa... Revert "Remove redundant executable testcases"
         <property role="O23RN" value="true" />
         <node concept="26Vqph" id="5eDFAXBNJc1" role="2C2TGm">
           <property role="2caQfQ" value="false" />
           <property role="2c7vTL" value="true" />
-<<<<<<< HEAD
-=======
         <node concept="26Vqph" id="72UYQRXZOnn" role="2C2TGm">
           <property role="2caQfQ" value="true" />
           <property role="2c7vTL" value="false" />
->>>>>>> 27c73b6b9d... New and Delete keywords are working, also has executable test and typesystem test
-        </node>
-        <node concept="3TlMh9" id="72UYQRXZOoq" role="3XIe9v">
-=======
         </node>
         <node concept="3TlMh9" id="5eDFAXBNJcA" role="3XIe9v">
->>>>>>> 8a9c6733aa... Revert "Remove redundant executable testcases"
           <property role="2hmy$m" value="0" />
         </node>
       </node>
@@ -480,6 +418,7 @@
       <property role="3HjyOP" value="true" />
       <property role="TrG5h" value="FunctionSpecifiers" />
     </node>
+  </node>
   </node>
 </model>
 

--- a/tests/test.ex.com.mbeddr.cpp/models/specifier.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/specifier.mps
@@ -5,9 +5,7 @@
     <engage id="236f3e56-2360-4657-9b9d-0cb84f56784d" name="com.mbeddr.cpp.modules.gen" />
     <devkit ref="bdd1ab49-ce55-4bff-86d1-5394fa0aa930(com.mbeddr.cpp)" />
   </languages>
-  <imports>
-    <import index="3y0n" ref="r:d4d16117-20fb-4ba8-a1b2-1598e121e1d0(com.mbeddr.core.stdlib)" />
-  </imports>
+  <imports />
   <registry>
     <language id="a9d69647-0840-491e-bf39-2eb0805d2011" name="com.mbeddr.core.statements">
       <concept id="4185783222026475238" name="com.mbeddr.core.statements.structure.LocalVariableDeclaration" flags="ng" index="3XIRlf">
@@ -23,7 +21,7 @@
     </language>
     <language id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig">
       <concept id="5046689135693761556" name="com.mbeddr.core.buildconfig.structure.Binary" flags="ng" index="2eOfOj">
-        <reference id="2504745233808502246" name="target" index="3oK8_y" />
+        <reference id="2504745233808502246" name="target_old" index="3oK8_y" />
         <child id="5046689135693761559" name="referencedModules" index="2eOfOg" />
       </concept>
       <concept id="5046689135693761554" name="com.mbeddr.core.buildconfig.structure.Executable" flags="ng" index="2eOfOl">
@@ -31,21 +29,21 @@
       </concept>
       <concept id="7717755763392524104" name="com.mbeddr.core.buildconfig.structure.BuildConfiguration" flags="ng" index="2v9HqL">
         <child id="5046689135694070731" name="binaries" index="2ePNbc" />
-        <child id="5323740605968447026" name="target" index="2AWWZH" />
+        <child id="5323740605968447026" name="platform" index="2AWWZH" />
       </concept>
       <concept id="7717755763392524107" name="com.mbeddr.core.buildconfig.structure.ModuleRef" flags="ng" index="2v9HqM">
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
       <concept id="5323740605968447019" name="com.mbeddr.core.buildconfig.structure.Platform" flags="ng" index="2AWWZO">
         <child id="1485382076185232212" name="targets" index="3anu1O" />
       </concept>
-      <concept id="1485382076184236780" name="com.mbeddr.core.buildconfig.structure.Target" flags="ng" index="3abb7c" />
+      <concept id="1485382076184236780" name="com.mbeddr.core.buildconfig.structure.System" flags="ng" index="3abb7c" />
       <concept id="2736179788492003936" name="com.mbeddr.core.buildconfig.structure.IDebuggablePlatform" flags="ng" index="1FkSt_">
         <property id="2736179788492003937" name="debugOptions" index="1FkSt$" />
       </concept>
@@ -62,23 +60,23 @@
       </concept>
     </language>
     <language id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base">
-      <concept id="2277423264798216734" name="com.mbeddr.cpp.base.structure.IStaticFlagConcept" flags="ng" index="226hDU">
+      <concept id="2277423264798216734" name="com.mbeddr.cpp.base.structure.IStaticFlag" flags="ng" index="226hDU">
         <property id="2277423264798216735" name="isStatic" index="226hDV" />
       </concept>
-      <concept id="2277423264798199359" name="com.mbeddr.cpp.base.structure.IInlineFlagConcept" flags="ng" index="226Gpr">
+      <concept id="2277423264798199359" name="com.mbeddr.cpp.base.structure.IInlineFlag" flags="ng" index="226Gpr">
         <property id="2277423264798199360" name="isInlined" index="226Go$" />
       </concept>
       <concept id="7240228573262412204" name="com.mbeddr.cpp.base.structure.LocalClassVariableDeclaration" flags="ng" index="2dywKE" />
-      <concept id="3188920472788366140" name="com.mbeddr.cpp.base.structure.IVirtualFlagConcept" flags="ng" index="hL25U">
+      <concept id="3188920472788366140" name="com.mbeddr.cpp.base.structure.IVirtualFlag" flags="ng" index="hL25U">
         <property id="3188920472788366141" name="isVirtual" index="hL25V" />
       </concept>
-      <concept id="3188920472790477822" name="com.mbeddr.cpp.base.structure.IPureVirtualFlagConcept" flags="ng" index="hTfAS">
+      <concept id="3188920472790477822" name="com.mbeddr.cpp.base.structure.IPureVirtualFlag" flags="ng" index="hTfAS">
         <property id="3188920472790477826" name="isPureVirtual" index="hTfT4" />
       </concept>
-      <concept id="6028541369715364763" name="com.mbeddr.cpp.base.structure.IVolatileFlagConcept" flags="ng" index="O23RO">
+      <concept id="6028541369715364763" name="com.mbeddr.cpp.base.structure.IVolatileFlag" flags="ng" index="O23RO">
         <property id="6028541369715364764" name="isVolatile" index="O23RN" />
       </concept>
-      <concept id="6028541369719415919" name="com.mbeddr.cpp.base.structure.IConstExprFlagConcept" flags="ng" index="OtGC0">
+      <concept id="6028541369719415919" name="com.mbeddr.cpp.base.structure.IConstExprFlag" flags="ng" index="OtGC0">
         <property id="6028541369719415920" name="isConstExpr" index="OtGCv" />
       </concept>
       <concept id="5044697665789382396" name="com.mbeddr.cpp.base.structure.MethodDeclaration" flags="ng" index="3mB1cK">
@@ -91,7 +89,7 @@
         <property id="2995459757115087788" name="visibility" index="1wg9_F" />
       </concept>
       <concept id="5044697665789405022" name="com.mbeddr.cpp.base.structure.ClassType" flags="ng" index="3mBfEi">
-        <reference id="5044697665789405054" name="clazz" index="3mBfEM" />
+        <reference id="5044697665789405054" name="class" index="3mBfEM" />
       </concept>
       <concept id="5044697665789336950" name="com.mbeddr.cpp.base.structure.ClassDeclaration" flags="ng" index="3mBW2U">
         <child id="5044697665789396304" name="members" index="3mBdys" />
@@ -122,7 +120,7 @@
         <child id="7755897872837031764" name="expected" index="2N2GHh" />
       </concept>
       <concept id="7755897872837082045" name="com.mbeddr.core.unittest.structure.AssertEquals" flags="ng" index="2N2KuS" />
-      <concept id="8610007178384196427" name="com.mbeddr.core.unittest.structure.TestCaseConfigItem" flags="ng" index="12mU2y">
+      <concept id="8610007178384196427" name="com.mbeddr.core.unittest.structure.UnitTestConfigItem" flags="ng" index="12mU2y">
         <child id="842732463503928104" name="testStrategy" index="3GpDut" />
       </concept>
       <concept id="842732463503928106" name="com.mbeddr.core.unittest.structure.NoTestIsolationStrategy" flags="ng" index="3GpDuv" />
@@ -208,31 +206,31 @@
       <node concept="3u$6M4" id="72UYQRXZOKS" role="3mBdys" />
       <node concept="3mBbG7" id="72UYQRXZOVH" role="3mBdys">
         <property role="1wg9_F" value="public" />
-      <node concept="3mBbG7" id="5eDFAXBt0Dc" role="3mBdys">
-        <property role="TrG5h" value="staticField" />
-        <property role="226hDV" value="true" />
-        <property role="1wg9_F" value="public" />
-        <property role="OtGCv" value="true" />
-        <node concept="3TlMh9" id="6Rfiwa9LP0Z" role="3XIe9v">
-          <property role="2hmy$m" value="111" />
+        <node concept="3mBbG7" id="5eDFAXBt0Dc" role="3mBdys">
+          <property role="TrG5h" value="staticField" />
+          <property role="226hDV" value="true" />
+          <property role="1wg9_F" value="public" />
+          <property role="OtGCv" value="true" />
+          <node concept="3TlMh9" id="6Rfiwa9LP0Z" role="3XIe9v">
+            <property role="2hmy$m" value="111" />
+          </node>
+          <node concept="26Vqph" id="5eDFAXBt0Ga" role="2C2TGm">
+            <property role="2caQfQ" value="false" />
+            <property role="2c7vTL" value="false" />
+          </node>
+          <node concept="3TlMh9" id="72UYQRXZP0d" role="3XIe9v">
+            <property role="2hmy$m" value="0" />
+          </node>
         </node>
-        <node concept="26Vqph" id="5eDFAXBt0Ga" role="2C2TGm">
+        <node concept="3u$6M4" id="5eDFAXBt0Ao" role="3mBdys" />
+        <node concept="3mBbG7" id="72UYQRXZO_2" role="3mBdys">
+          <property role="TrG5h" value="constField" />
+          <property role="1wg9_F" value="public" />
           <property role="2caQfQ" value="false" />
           <property role="2c7vTL" value="false" />
         </node>
-        <node concept="3TlMh9" id="72UYQRXZP0d" role="3XIe9v">
-          <property role="2hmy$m" value="0" />
-        </node>
       </node>
-      <node concept="3u$6M4" id="5eDFAXBt0Ao" role="3mBdys" />
-      <node concept="3mBbG7" id="72UYQRXZO_2" role="3mBdys">
-        <property role="TrG5h" value="constField" />
-        <property role="1wg9_F" value="public" />
-          <property role="2caQfQ" value="false" />
-          <property role="2c7vTL" value="false" />
-        </node>
-      </node>
-      <node concept="3u$6M4" id="5eDFAXBt0Ao" role="3mBdys" />
+      <node concept="3u$6M4" id="w$yjPEBKaT" role="3mBdys" />
       <node concept="3mBbG7" id="5eDFAXBNIRy" role="3mBdys">
         <property role="TrG5h" value="constField" />
         <property role="1wg9_F" value="public" />
@@ -265,160 +263,160 @@
         <node concept="26Vqph" id="5eDFAXBNJc1" role="2C2TGm">
           <property role="2caQfQ" value="false" />
           <property role="2c7vTL" value="true" />
-        <node concept="26Vqph" id="72UYQRXZOnn" role="2C2TGm">
-          <property role="2caQfQ" value="true" />
-          <property role="2c7vTL" value="false" />
-        </node>
-        <node concept="3TlMh9" id="5eDFAXBNJcA" role="3XIe9v">
-          <property role="2hmy$m" value="0" />
-        </node>
-      </node>
-      <node concept="3u$6M4" id="5eDFAXBNIOA" role="3mBdys" />
-      <node concept="3mB1cK" id="1Yr26iukrNB" role="3mBdys">
-        <property role="TrG5h" value="inlinedMethod" />
-        <property role="226Go$" value="true" />
-        <property role="1wg9_F" value="public" />
-        <property role="OtGCv" value="false" />
-        <node concept="26Vqph" id="1Yr26iukrNM" role="2C2TGm">
-          <property role="2caQfQ" value="false" />
-          <property role="2c7vTL" value="false" />
-        </node>
-        <node concept="3XIRFW" id="1Yr26iukrO8" role="3XIRFX">
-          <node concept="2BFjQ_" id="1Yr26iukrOE" role="3XIRFZ">
-            <node concept="3TlMh9" id="1Yr26iukrOS" role="2BFjQA">
-              <property role="2hmy$m" value="32" />
-            </node>
+          <node concept="26Vqph" id="72UYQRXZOnn" role="2C2TGm">
+            <property role="2caQfQ" value="true" />
+            <property role="2c7vTL" value="false" />
+          </node>
+          <node concept="3TlMh9" id="5eDFAXBNJcA" role="3XIe9v">
+            <property role="2hmy$m" value="0" />
           </node>
         </node>
-      </node>
-      <node concept="3u$6M4" id="1Yr26iukrWG" role="3mBdys" />
-      <node concept="3mB1cK" id="1Yr26iukrYm" role="3mBdys">
-        <property role="TrG5h" value="staticMethod" />
-        <property role="226hDV" value="true" />
-        <property role="hL25V" value="false" />
-        <property role="hTfT4" value="false" />
-        <node concept="26Vqph" id="1Yr26iukrZX" role="2C2TGm">
-          <property role="2caQfQ" value="false" />
-          <property role="2c7vTL" value="false" />
-        </node>
-        <node concept="3XIRFW" id="1Yr26iuks0j" role="3XIRFX">
-          <node concept="3XIRlf" id="5eDFAXBNZnl" role="3XIRFZ">
-            <property role="TrG5h" value="test" />
-            <node concept="26Vqph" id="5eDFAXBNZnj" role="2C2TGm">
-              <property role="2caQfQ" value="false" />
-              <property role="2c7vTL" value="false" />
-            </node>
-            <node concept="3TlMh9" id="5eDFAXBNZoJ" role="3XIe9u">
-              <property role="2hmy$m" value="1" />
-            </node>
-          </node>
-          <node concept="2BFjQ_" id="1Yr26iuks0Q" role="3XIRFZ">
-            <node concept="3TlMh9" id="1Yr26iuks14" role="2BFjQA">
-              <property role="2hmy$m" value="0" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3u$6M4" id="1Yr26iuks3z" role="3mBdys" />
-      <node concept="3mB1cK" id="1Yr26iuks6b" role="3mBdys">
-        <property role="TrG5h" value="staticInlinedMethod" />
-        <property role="226hDV" value="true" />
-        <property role="226Go$" value="true" />
-        <node concept="26Vqph" id="1Yr26iuks8$" role="2C2TGm">
-          <property role="2caQfQ" value="false" />
-          <property role="2c7vTL" value="false" />
-        </node>
-        <node concept="3XIRFW" id="1Yr26iuks8Z" role="3XIRFX">
-          <node concept="2BFjQ_" id="1Yr26iuks9n" role="3XIRFZ">
-            <node concept="3TlMh9" id="1Yr26iuks9v" role="2BFjQA">
-              <property role="2hmy$m" value="0" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2NXPZ9" id="1Yr26iuksrh" role="N3F5h">
-      <property role="TrG5h" value="empty_1527243997568_3" />
-    </node>
-    <node concept="c0Qz5" id="6Rfiwa9LMCu" role="N3F5h">
-      <property role="2OOxQR" value="true" />
-      <property role="TrG5h" value="test_specifiers" />
-      <node concept="19Rifw" id="6Rfiwa9LMCv" role="2C2TGm">
-        <property role="2caQfQ" value="false" />
-        <property role="2c7vTL" value="false" />
-      </node>
-      <node concept="3XIRFW" id="6Rfiwa9LMCx" role="c0Qz3">
-        <node concept="2dywKE" id="6Rfiwa9LN5E" role="3XIRFZ">
-          <property role="TrG5h" value="anInstance" />
-          <node concept="3mBfEi" id="6Rfiwa9LN5D" role="2C2TGm">
+        <node concept="3u$6M4" id="5eDFAXBNIOA" role="3mBdys" />
+        <node concept="3mB1cK" id="1Yr26iukrNB" role="3mBdys">
+          <property role="TrG5h" value="inlinedMethod" />
+          <property role="226Go$" value="true" />
+          <property role="1wg9_F" value="public" />
+          <property role="OtGCv" value="false" />
+          <node concept="26Vqph" id="1Yr26iukrNM" role="2C2TGm">
             <property role="2caQfQ" value="false" />
             <property role="2c7vTL" value="false" />
-            <ref role="3mBfEM" node="1Yr26iukrN$" resolve="SomeClass" />
           </node>
-        </node>
-        <node concept="3XISUE" id="6Rfiwa9LN6k" role="3XIRFZ" />
-        <node concept="2N2KuS" id="6Rfiwa9LN71" role="3XIRFZ">
-          <node concept="3TlMh9" id="6Rfiwa9LNdD" role="2N2GHh">
-            <property role="2hmy$m" value="3" />
-          </node>
-          <node concept="2qmXGp" id="6Rfiwa9LNd2" role="2N2GHg">
-            <node concept="3mBk1D" id="6Rfiwa9LNds" role="1ESnxz">
-              <ref role="3mBk1B" node="5eDFAXBNIRy" resolve="constField" />
-            </node>
-            <node concept="3ZVu4v" id="6Rfiwa9LNcT" role="1_9fRO">
-              <ref role="3ZVs_2" node="6Rfiwa9LN5E" resolve="anInstance" />
+          <node concept="3XIRFW" id="1Yr26iukrO8" role="3XIRFX">
+            <node concept="2BFjQ_" id="1Yr26iukrOE" role="3XIRFZ">
+              <node concept="3TlMh9" id="1Yr26iukrOS" role="2BFjQA">
+                <property role="2hmy$m" value="32" />
+              </node>
             </node>
           </node>
         </node>
-        <node concept="2N2KuS" id="6Rfiwa9LNoA" role="3XIRFZ">
-          <node concept="3TlMh9" id="6Rfiwa9LN_c" role="2N2GHh">
-            <property role="2hmy$m" value="5" />
+        <node concept="3u$6M4" id="1Yr26iukrWG" role="3mBdys" />
+        <node concept="3mB1cK" id="1Yr26iukrYm" role="3mBdys">
+          <property role="TrG5h" value="staticMethod" />
+          <property role="226hDV" value="true" />
+          <property role="hL25V" value="false" />
+          <property role="hTfT4" value="false" />
+          <node concept="26Vqph" id="1Yr26iukrZX" role="2C2TGm">
+            <property role="2caQfQ" value="false" />
+            <property role="2c7vTL" value="false" />
           </node>
-          <node concept="2qmXGp" id="6Rfiwa9LNpx" role="2N2GHg">
-            <node concept="3mBk1D" id="6Rfiwa9LN$Z" role="1ESnxz">
-              <ref role="3mBk1B" node="5eDFAXBNIZY" resolve="volatileField" />
+          <node concept="3XIRFW" id="1Yr26iuks0j" role="3XIRFX">
+            <node concept="3XIRlf" id="5eDFAXBNZnl" role="3XIRFZ">
+              <property role="TrG5h" value="test" />
+              <node concept="26Vqph" id="5eDFAXBNZnj" role="2C2TGm">
+                <property role="2caQfQ" value="false" />
+                <property role="2c7vTL" value="false" />
+              </node>
+              <node concept="3TlMh9" id="5eDFAXBNZoJ" role="3XIe9u">
+                <property role="2hmy$m" value="1" />
+              </node>
             </node>
-            <node concept="3ZVu4v" id="6Rfiwa9LNpo" role="1_9fRO">
-              <ref role="3ZVs_2" node="6Rfiwa9LN5E" resolve="anInstance" />
+            <node concept="2BFjQ_" id="1Yr26iuks0Q" role="3XIRFZ">
+              <node concept="3TlMh9" id="1Yr26iuks14" role="2BFjQA">
+                <property role="2hmy$m" value="0" />
+              </node>
             </node>
           </node>
         </node>
-        <node concept="2N2KuS" id="6Rfiwa9LO9P" role="3XIRFZ">
-          <node concept="3TlMh9" id="6Rfiwa9LOpg" role="2N2GHh">
-            <property role="2hmy$m" value="32" />
+        <node concept="3u$6M4" id="1Yr26iuks3z" role="3mBdys" />
+        <node concept="3mB1cK" id="1Yr26iuks6b" role="3mBdys">
+          <property role="TrG5h" value="staticInlinedMethod" />
+          <property role="226hDV" value="true" />
+          <property role="226Go$" value="true" />
+          <node concept="26Vqph" id="1Yr26iuks8$" role="2C2TGm">
+            <property role="2caQfQ" value="false" />
+            <property role="2c7vTL" value="false" />
           </node>
-          <node concept="2qmXGp" id="6Rfiwa9LOaW" role="2N2GHg">
-            <node concept="3mBbHP" id="6Rfiwa9LOp1" role="1ESnxz">
-              <ref role="3mBbHN" node="1Yr26iukrNB" resolve="inlinedMethod" />
-            </node>
-            <node concept="3ZVu4v" id="6Rfiwa9LOaN" role="1_9fRO">
-              <ref role="3ZVs_2" node="6Rfiwa9LN5E" resolve="anInstance" />
-            </node>
-          </node>
-        </node>
-        <node concept="2N2KuS" id="6Rfiwa9LP3Q" role="3XIRFZ">
-          <node concept="3TlMh9" id="6Rfiwa9LPld" role="2N2GHh">
-            <property role="2hmy$m" value="111" />
-          </node>
-          <node concept="2qmXGp" id="6Rfiwa9LP57" role="2N2GHg">
-            <node concept="3mBk1D" id="6Rfiwa9LPl0" role="1ESnxz">
-              <ref role="3mBk1B" node="5eDFAXBt0Dc" resolve="staticField" />
-            </node>
-            <node concept="3ZVu4v" id="6Rfiwa9LP4Y" role="1_9fRO">
-              <ref role="3ZVs_2" node="6Rfiwa9LN5E" resolve="anInstance" />
+          <node concept="3XIRFW" id="1Yr26iuks8Z" role="3XIRFX">
+            <node concept="2BFjQ_" id="1Yr26iuks9n" role="3XIRFZ">
+              <node concept="3TlMh9" id="1Yr26iuks9v" role="2BFjQA">
+                <property role="2hmy$m" value="0" />
+              </node>
             </node>
           </node>
         </node>
       </node>
+      <node concept="2NXPZ9" id="1Yr26iuksrh" role="N3F5h">
+        <property role="TrG5h" value="empty_1527243997568_3" />
+      </node>
+      <node concept="c0Qz5" id="6Rfiwa9LMCu" role="N3F5h">
+        <property role="2OOxQR" value="true" />
+        <property role="TrG5h" value="test_specifiers" />
+        <node concept="19Rifw" id="6Rfiwa9LMCv" role="2C2TGm">
+          <property role="2caQfQ" value="false" />
+          <property role="2c7vTL" value="false" />
+        </node>
+        <node concept="3XIRFW" id="6Rfiwa9LMCx" role="c0Qz3">
+          <node concept="2dywKE" id="6Rfiwa9LN5E" role="3XIRFZ">
+            <property role="TrG5h" value="anInstance" />
+            <node concept="3mBfEi" id="6Rfiwa9LN5D" role="2C2TGm">
+              <property role="2caQfQ" value="false" />
+              <property role="2c7vTL" value="false" />
+              <ref role="3mBfEM" node="1Yr26iukrN$" resolve="SomeClass" />
+            </node>
+          </node>
+          <node concept="3XISUE" id="6Rfiwa9LN6k" role="3XIRFZ" />
+          <node concept="2N2KuS" id="6Rfiwa9LN71" role="3XIRFZ">
+            <node concept="3TlMh9" id="6Rfiwa9LNdD" role="2N2GHh">
+              <property role="2hmy$m" value="3" />
+            </node>
+            <node concept="2qmXGp" id="6Rfiwa9LNd2" role="2N2GHg">
+              <node concept="3mBk1D" id="6Rfiwa9LNds" role="1ESnxz">
+                <ref role="3mBk1B" node="5eDFAXBNIRy" resolve="constField" />
+              </node>
+              <node concept="3ZVu4v" id="6Rfiwa9LNcT" role="1_9fRO">
+                <ref role="3ZVs_2" node="6Rfiwa9LN5E" resolve="anInstance" />
+              </node>
+            </node>
+          </node>
+          <node concept="2N2KuS" id="6Rfiwa9LNoA" role="3XIRFZ">
+            <node concept="3TlMh9" id="6Rfiwa9LN_c" role="2N2GHh">
+              <property role="2hmy$m" value="5" />
+            </node>
+            <node concept="2qmXGp" id="6Rfiwa9LNpx" role="2N2GHg">
+              <node concept="3mBk1D" id="6Rfiwa9LN$Z" role="1ESnxz">
+                <ref role="3mBk1B" node="5eDFAXBNIZY" resolve="volatileField" />
+              </node>
+              <node concept="3ZVu4v" id="6Rfiwa9LNpo" role="1_9fRO">
+                <ref role="3ZVs_2" node="6Rfiwa9LN5E" resolve="anInstance" />
+              </node>
+            </node>
+          </node>
+          <node concept="2N2KuS" id="6Rfiwa9LO9P" role="3XIRFZ">
+            <node concept="3TlMh9" id="6Rfiwa9LOpg" role="2N2GHh">
+              <property role="2hmy$m" value="32" />
+            </node>
+            <node concept="2qmXGp" id="6Rfiwa9LOaW" role="2N2GHg">
+              <node concept="3mBbHP" id="6Rfiwa9LOp1" role="1ESnxz">
+                <ref role="3mBbHN" node="1Yr26iukrNB" resolve="inlinedMethod" />
+              </node>
+              <node concept="3ZVu4v" id="6Rfiwa9LOaN" role="1_9fRO">
+                <ref role="3ZVs_2" node="6Rfiwa9LN5E" resolve="anInstance" />
+              </node>
+            </node>
+          </node>
+          <node concept="2N2KuS" id="6Rfiwa9LP3Q" role="3XIRFZ">
+            <node concept="3TlMh9" id="6Rfiwa9LPld" role="2N2GHh">
+              <property role="2hmy$m" value="111" />
+            </node>
+            <node concept="2qmXGp" id="6Rfiwa9LP57" role="2N2GHg">
+              <node concept="3mBk1D" id="6Rfiwa9LPl0" role="1ESnxz">
+                <ref role="3mBk1B" node="5eDFAXBt0Dc" resolve="staticField" />
+              </node>
+              <node concept="3ZVu4v" id="6Rfiwa9LP4Y" role="1_9fRO">
+                <ref role="3ZVs_2" node="6Rfiwa9LN5E" resolve="anInstance" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2NXPZ9" id="6Rfiwa9LMv7" role="N3F5h">
+        <property role="TrG5h" value="empty_1528717614348_2" />
+      </node>
+      <node concept="lIfQi" id="1Yr26iuksuV" role="N3F5h">
+        <property role="3HjyOP" value="true" />
+        <property role="TrG5h" value="FunctionSpecifiers" />
+      </node>
     </node>
-    <node concept="2NXPZ9" id="6Rfiwa9LMv7" role="N3F5h">
-      <property role="TrG5h" value="empty_1528717614348_2" />
-    </node>
-    <node concept="lIfQi" id="1Yr26iuksuV" role="N3F5h">
-      <property role="3HjyOP" value="true" />
-      <property role="TrG5h" value="FunctionSpecifiers" />
-    </node>
-  </node>
   </node>
 </model>
 

--- a/tests/test.ex.com.mbeddr.cpp/models/templates.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/templates.mps
@@ -58,9 +58,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -288,7 +289,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
     <node concept="2eOfOl" id="4o2nsMgBpPF" role="2ePNbc">
       <property role="TrG5h" value="ex" />

--- a/tests/test.ex.com.mbeddr.cpp/models/thisPointer.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/thisPointer.mps
@@ -43,9 +43,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -208,7 +209,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
     <node concept="2eOfOl" id="4o2nsMgBpPF" role="2ePNbc">
       <property role="TrG5h" value="ThisPointer" />

--- a/tests/test.ex.com.mbeddr.cpp/models/typeInference.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/typeInference.mps
@@ -36,9 +36,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -166,7 +167,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
   <node concept="1whW_1" id="2O2YBLCmwEn">

--- a/tests/test.ex.com.mbeddr.cpp/models/virtual.mps
+++ b/tests/test.ex.com.mbeddr.cpp/models/virtual.mps
@@ -47,9 +47,10 @@
         <reference id="7717755763392524108" name="module" index="2v9HqP" />
       </concept>
       <concept id="5323740605968447022" name="com.mbeddr.core.buildconfig.structure.DesktopPlatform" flags="ng" index="2AWWZL">
-        <property id="5323740605968447025" name="compilerOptions" index="2AWWZI" />
-        <property id="5323740605968447024" name="compiler" index="2AWWZJ" />
-        <property id="8774011376396215812" name="linker" index="18_EFo" />
+        <property id="5323740605968447025" name="cCompilerOptions" index="2AWWZI" />
+        <property id="5323740605968447024" name="cCompiler" index="2AWWZJ" />
+        <property id="1253797277664981186" name="cppCompilerOptions" index="UXd4T" />
+        <property id="1253797277664981177" name="cppCompiler" index="UXd52" />
         <property id="3963667026125442601" name="gdb" index="3r8Kw1" />
         <property id="3963667026125442676" name="make" index="3r8Kxs" />
       </concept>
@@ -188,7 +189,8 @@
       <property role="3r8Kxs" value="make" />
       <property role="1FkSt$" value="-g" />
       <property role="2AWWZI" value=" " />
-      <property role="18_EFo" value="gcc" />
+      <property role="UXd52" value="g++" />
+      <property role="UXd4T" value="-std=c++11" />
     </node>
   </node>
   <node concept="1whW_1" id="6KmaLbE81Ky">

--- a/tests/test.ex.com.mbeddr.cpp/test.ex.com.mbeddr.cpp.msd
+++ b/tests/test.ex.com.mbeddr.cpp/test.ex.com.mbeddr.cpp.msd
@@ -16,7 +16,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2d7fadf5-33f6-4e80-a78f-0f739add2bde:com.mbeddr.core.buildconfig" version="9" />
+    <language slang="l:2d7fadf5-33f6-4e80-a78f-0f739add2bde:com.mbeddr.core.buildconfig" version="10" />
     <language slang="l:b2da2e1a-b542-47f5-9be0-4dc21efe74a4:com.mbeddr.core.checks" version="0" />
     <language slang="l:390de4af-0c8d-4716-8dec-3d05ca751b28:com.mbeddr.core.cinterpreter" version="0" />
     <language slang="l:223dd778-c44f-4ef3-9535-7aa7d12244a6:com.mbeddr.core.debug" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/arrayinit@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/arrayinit@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />
     <use id="b341759a-c721-4072-90cf-328bb2724684" name="com.mbeddr.cpp.expressions" version="0" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/attributes@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/attributes@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/casting@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/casting@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/constructor@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/constructor@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/constructorinitializable@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/constructorinitializable@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />

--- a/tests/test.ts.com.mbeddr.cpp/models/globalvars@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/globalvars@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />

--- a/tests/test.ts.com.mbeddr.cpp/models/identifiernames@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/identifiernames@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />

--- a/tests/test.ts.com.mbeddr.cpp/models/inheritance@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/inheritance@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />

--- a/tests/test.ts.com.mbeddr.cpp/models/method@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/method@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/namespace@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/namespace@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/operatorOverloading@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/operatorOverloading@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/polymorphism@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/polymorphism@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/staticclassmethodcall@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/staticclassmethodcall@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="783af01f-87a7-412c-be99-293a162652b5" name="com.mbeddr.core.embedded" version="1" />

--- a/tests/test.ts.com.mbeddr.cpp/models/templatetypes@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/templatetypes@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="5e6018dc-dc26-4070-9526-663fdbfe4c10" name="com.mbeddr.cpp.templates" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/trycatch@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/trycatch@tests.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="dd4979e3-3be6-46b3-9e1e-c36309e30758" name="com.mbeddr.cpp.modules" version="0" />
     <use id="2e15e1a4-8998-4f06-86b2-8d184a179e8e" name="com.mbeddr.cpp.exceptions" version="0" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/models/typeInference@tests.mps
+++ b/tests/test.ts.com.mbeddr.cpp/models/typeInference@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="8c081446-e4ba-48b7-a7e0-3db40e2c3439" name="com.mbeddr.cpp.base" version="0" />
-    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="9" />
+    <use id="2d7fadf5-33f6-4e80-a78f-0f739add2bde" name="com.mbeddr.core.buildconfig" version="10" />
     <use id="a9d69647-0840-491e-bf39-2eb0805d2011" name="com.mbeddr.core.statements" version="2" />
     <use id="2693fc71-9b0e-4b05-ab13-f57227d675f2" name="com.mbeddr.core.util" version="0" />
     <use id="6d11763d-483d-4b2b-8efc-09336c1b0001" name="com.mbeddr.core.modules" version="5" />

--- a/tests/test.ts.com.mbeddr.cpp/test.ts.com.mbeddr.cpp.msd
+++ b/tests/test.ts.com.mbeddr.cpp/test.ts.com.mbeddr.cpp.msd
@@ -21,7 +21,7 @@
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
-    <language slang="l:2d7fadf5-33f6-4e80-a78f-0f739add2bde:com.mbeddr.core.buildconfig" version="9" />
+    <language slang="l:2d7fadf5-33f6-4e80-a78f-0f739add2bde:com.mbeddr.core.buildconfig" version="10" />
     <language slang="l:b2da2e1a-b542-47f5-9be0-4dc21efe74a4:com.mbeddr.core.checks" version="0" />
     <language slang="l:390de4af-0c8d-4716-8dec-3d05ca751b28:com.mbeddr.core.cinterpreter" version="0" />
     <language slang="l:223dd778-c44f-4ef3-9535-7aa7d12244a6:com.mbeddr.core.debug" version="0" />


### PR DESCRIPTION
Catch up with some cleanup after MPS 2020.3 migration. The comment in the commits about it being strange that more (albeit inconsequential) migrations were needed, can now be explained: I was using a "wrong" version of dependencies on mbeddr and mbeddr.platform, as will be mitigated by #22.