### PR TITLE
Migration/2021 2

### DIFF
--- a/.mps/migration.xml
+++ b/.mps/migration.xml
@@ -5,5 +5,7 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v191.SaveAllJavaStubMethodRefsToShortForeignFormat" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v191.UpdateJavaStubMethodRefs" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
+    <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
+    <entry key="project.migrated.version" value="212" />
   </component>
 </project>

--- a/_spreferences/PlatformTemplates/module.msd
+++ b/_spreferences/PlatformTemplates/module.msd
@@ -32,7 +32,7 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />

--- a/_spreferences/TypeSizeConfiguration/module.msd
+++ b/_spreferences/TypeSizeConfiguration/module.msd
@@ -25,7 +25,7 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,8 @@ configurations {
 }
 
 dependencies {
-    mps "com.jetbrains:mps:2021.1.+"
-    languageLibs "com.mbeddr:mbeddr:2021.1.+"
+    mps "com.jetbrains:mps:2021.2.+"
+    languageLibs "com.mbeddr:mbeddr:2021.2.+"
     junitAnt 'org.apache.ant:ant-junit:1.10.6'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-mbeddrCppVersion = 2021.1
+mbeddrCppVersion = 2021.2
 systemProp.org.gradle.internal.http.connectionTimeout=180000
 systemProp.org.gradle.internal.http.socketTimeout=180000

--- a/languages/com.mbeddr.cpp.base/com.mbeddr.cpp.base.mpl
+++ b/languages/com.mbeddr.cpp.base/com.mbeddr.cpp.base.mpl
@@ -59,6 +59,7 @@
     <language slang="l:97a52717-898f-4598-8150-573d9fd03868:jetbrains.mps.lang.dataFlow.analyzers" version="0" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:b1ab8c10-c118-4755-bf2a-cebab35cf533:jetbrains.mps.lang.editor.tooltips" version="0" />
     <language slang="l:64d34fcd-ad02-4e73-aff8-a581124c2e30:jetbrains.mps.lang.findUsages" version="0" />
     <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
     <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />

--- a/languages/com.mbeddr.cpp.base/com.mbeddr.cpp.base.mpl
+++ b/languages/com.mbeddr.cpp.base/com.mbeddr.cpp.base.mpl
@@ -73,7 +73,7 @@
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:0eddeefa-c2d6-4437-bc2c-de50fd4ce470:jetbrains.mps.lang.script" version="1" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />

--- a/languages/com.mbeddr.cpp.base/models/com.mbeddr.cpp.base.editor.mps
+++ b/languages/com.mbeddr.cpp.base/models/com.mbeddr.cpp.base.editor.mps
@@ -4,11 +4,11 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
-    <use id="a0ab8c10-c118-4755-ba27-3853435cf524" name="de.itemis.mps.tooltips" version="1" />
     <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="-1" />
     <use id="b4f35ed8-45af-4efa-abe4-00ac26956e69" name="com.mbeddr.mpsutil.grammarcells.runtimelang" version="-1" />
     <use id="9ded098b-ad6a-4657-bfd9-48636cfe8bc3" name="jetbrains.mps.lang.traceable" version="-1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
   <imports>

--- a/languages/com.mbeddr.cpp.base/models/com.mbeddr.cpp.base.typesystem.mps
+++ b/languages/com.mbeddr.cpp.base/models/com.mbeddr.cpp.base.typesystem.mps
@@ -320,6 +320,7 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="8329979535468945057" name="jetbrains.mps.lang.smodel.structure.Node_PresentationOperation" flags="ng" index="2Iv5rx" />
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
         <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
         <child id="1883223317721008709" name="body" index="Jncv$" />
@@ -772,8 +773,11 @@
                   <ref role="3cqZAo" node="4K6s$_sI$6_" resolve="instanceModule" />
                 </node>
                 <node concept="3cpWs3" id="4K6s$_sJ025" role="3uHU7B">
-                  <node concept="37vLTw" id="4K6s$_sIUX7" role="3uHU7B">
-                    <ref role="3cqZAo" node="4K6s$_sI1yj" resolve="parentClassModule" />
+                  <node concept="2OqwBi" id="6PsRtIQdxVb" role="3uHU7B">
+                    <node concept="37vLTw" id="4K6s$_sIUX7" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4K6s$_sI1yj" resolve="parentClassModule" />
+                    </node>
+                    <node concept="2Iv5rx" id="6PsRtIQdxVc" role="2OqNvi" />
                   </node>
                   <node concept="Xl_RD" id="4K6s$_sJ0ze" role="3uHU7w">
                     <property role="Xl_RC" value=" " />
@@ -795,8 +799,11 @@
               <node concept="Xl_RD" id="4K6s$_sIa7P" role="3uHU7B">
                 <property role="Xl_RC" value="you can't extend a class from another module unless you import the module; try importing " />
               </node>
-              <node concept="37vLTw" id="4K6s$_sJj7F" role="3uHU7w">
-                <ref role="3cqZAo" node="4K6s$_sI1yj" resolve="parentClassModule" />
+              <node concept="2OqwBi" id="6PsRtIQdxVm" role="3uHU7w">
+                <node concept="37vLTw" id="4K6s$_sJj7F" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4K6s$_sI1yj" resolve="parentClassModule" />
+                </node>
+                <node concept="2Iv5rx" id="6PsRtIQdxVn" role="2OqNvi" />
               </node>
             </node>
             <node concept="1YBJjd" id="4K6s$_sIa8m" role="1urrMF">
@@ -1611,13 +1618,16 @@
         <node concept="3clFbS" id="6hUtorEt3G8" role="3clFbx">
           <node concept="2MkqsV" id="6hUtorEt47E" role="3cqZAp">
             <node concept="3cpWs3" id="6hUtorEtrhL" role="2MkJ7o">
-              <node concept="2OqwBi" id="6hUtorEtrxp" role="3uHU7w">
-                <node concept="1YBJjd" id="6hUtorEtrli" role="2Oq$k0">
-                  <ref role="1YBMHb" node="6hUtorEt3G2" resolve="iClassTyped" />
+              <node concept="2OqwBi" id="6PsRtIQdxZt" role="3uHU7w">
+                <node concept="2OqwBi" id="6hUtorEtrxp" role="2Oq$k0">
+                  <node concept="1YBJjd" id="6hUtorEtrli" role="2Oq$k0">
+                    <ref role="1YBMHb" node="6hUtorEt3G2" resolve="iClassTyped" />
+                  </node>
+                  <node concept="3TrEf2" id="6hUtorEtrOE" role="2OqNvi">
+                    <ref role="3Tt5mk" to="mj1l:hEaDaGor64" resolve="type" />
+                  </node>
                 </node>
-                <node concept="3TrEf2" id="6hUtorEtrOE" role="2OqNvi">
-                  <ref role="3Tt5mk" to="mj1l:hEaDaGor64" resolve="type" />
-                </node>
+                <node concept="2Iv5rx" id="6PsRtIQdxZu" role="2OqNvi" />
               </node>
               <node concept="Xl_RD" id="6hUtorEt47T" role="3uHU7B">
                 <property role="Xl_RC" value="must be an instance of ClassType but is " />
@@ -5364,13 +5374,16 @@
                       <node concept="Xl_RD" id="72UYQRWzYDL" role="3uHU7B">
                         <property role="Xl_RC" value="type of " />
                       </node>
-                      <node concept="2OqwBi" id="72UYQRWzEMw" role="3uHU7w">
-                        <node concept="3TrEf2" id="72UYQRWzFmV" role="2OqNvi">
-                          <ref role="3Tt5mk" to="wnzg:72UYQRW0DPK" resolve="varRef" />
+                      <node concept="2OqwBi" id="6PsRtIQdy35" role="3uHU7w">
+                        <node concept="2OqwBi" id="72UYQRWzEMw" role="2Oq$k0">
+                          <node concept="3TrEf2" id="72UYQRWzFmV" role="2OqNvi">
+                            <ref role="3Tt5mk" to="wnzg:72UYQRW0DPK" resolve="varRef" />
+                          </node>
+                          <node concept="1YBJjd" id="72UYQRW$167" role="2Oq$k0">
+                            <ref role="1YBMHb" node="72UYQRWvwJo" resolve="dd" />
+                          </node>
                         </node>
-                        <node concept="1YBJjd" id="72UYQRW$167" role="2Oq$k0">
-                          <ref role="1YBMHb" node="72UYQRWvwJo" resolve="dd" />
-                        </node>
+                        <node concept="2Iv5rx" id="6PsRtIQdy36" role="2OqNvi" />
                       </node>
                     </node>
                     <node concept="Xl_RD" id="72UYQRW$3JQ" role="3uHU7w">

--- a/languages/com.mbeddr.cpp.buildconfig/com.mbeddr.cpp.buildconfig.mpl
+++ b/languages/com.mbeddr.cpp.buildconfig/com.mbeddr.cpp.buildconfig.mpl
@@ -51,7 +51,7 @@
         <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
         <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
         <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
         <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
         <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
         <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -174,7 +174,7 @@
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:0eddeefa-c2d6-4437-bc2c-de50fd4ce470:jetbrains.mps.lang.script" version="1" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />

--- a/languages/com.mbeddr.cpp.buildconfig/com.mbeddr.cpp.buildconfig.mpl
+++ b/languages/com.mbeddr.cpp.buildconfig/com.mbeddr.cpp.buildconfig.mpl
@@ -98,6 +98,7 @@
         <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+        <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
         <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
         <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
         <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />
@@ -149,7 +150,6 @@
     <language slang="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
     <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
@@ -208,6 +208,7 @@
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/languages/com.mbeddr.cpp.exceptions/com.mbeddr.cpp.exceptions.mpl
+++ b/languages/com.mbeddr.cpp.exceptions/com.mbeddr.cpp.exceptions.mpl
@@ -48,7 +48,7 @@
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />

--- a/languages/com.mbeddr.cpp.exceptions/com.mbeddr.cpp.exceptions.mpl
+++ b/languages/com.mbeddr.cpp.exceptions/com.mbeddr.cpp.exceptions.mpl
@@ -30,7 +30,6 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
     <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
@@ -83,6 +82,7 @@
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/languages/com.mbeddr.cpp.expressions/com.mbeddr.cpp.expressions.mpl
+++ b/languages/com.mbeddr.cpp.expressions/com.mbeddr.cpp.expressions.mpl
@@ -38,7 +38,6 @@
     <language slang="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
     <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
@@ -107,6 +106,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />

--- a/languages/com.mbeddr.cpp.expressions/com.mbeddr.cpp.expressions.mpl
+++ b/languages/com.mbeddr.cpp.expressions/com.mbeddr.cpp.expressions.mpl
@@ -64,7 +64,7 @@
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:0eddeefa-c2d6-4437-bc2c-de50fd4ce470:jetbrains.mps.lang.script" version="1" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />

--- a/languages/com.mbeddr.cpp.expressions/models/behavior.mps
+++ b/languages/com.mbeddr.cpp.expressions/models/behavior.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>

--- a/languages/com.mbeddr.cpp.expressions/models/textGen.mps
+++ b/languages/com.mbeddr.cpp.expressions/models/textGen.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="b83431fe-5c8f-40bc-8a36-65e25f4dd253" name="jetbrains.mps.lang.textGen" version="1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <devkit ref="fa73d85a-ac7f-447b-846c-fcdc41caa600(jetbrains.mps.devkit.aspect.textgen)" />
   </languages>
   <imports>

--- a/languages/com.mbeddr.cpp.expressions/models/typesystem.mps
+++ b/languages/com.mbeddr.cpp.expressions/models/typesystem.mps
@@ -185,6 +185,7 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="8329979535468945057" name="jetbrains.mps.lang.smodel.structure.Node_PresentationOperation" flags="ng" index="2Iv5rx" />
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
         <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
         <child id="1883223317721008709" name="body" index="Jncv$" />
@@ -1380,13 +1381,16 @@
                           <node concept="Xl_RD" id="3p40HKhESRM" role="3uHU7B">
                             <property role="Xl_RC" value="elements must be of type " />
                           </node>
-                          <node concept="2OqwBi" id="3p40HKhESRN" role="3uHU7w">
-                            <node concept="37vLTw" id="3p40HKhESRO" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3p40HKhBz7$" resolve="arraySpec" />
+                          <node concept="2OqwBi" id="6PsRtIQdy3Z" role="3uHU7w">
+                            <node concept="2OqwBi" id="3p40HKhESRN" role="2Oq$k0">
+                              <node concept="37vLTw" id="3p40HKhESRO" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3p40HKhBz7$" resolve="arraySpec" />
+                              </node>
+                              <node concept="3TrEf2" id="3p40HKhESRP" role="2OqNvi">
+                                <ref role="3Tt5mk" to="c4fa:6IWRcVPT6tm" resolve="baseType" />
+                              </node>
                             </node>
-                            <node concept="3TrEf2" id="3p40HKhESRP" role="2OqNvi">
-                              <ref role="3Tt5mk" to="c4fa:6IWRcVPT6tm" resolve="baseType" />
-                            </node>
+                            <node concept="2Iv5rx" id="6PsRtIQdy40" role="2OqNvi" />
                           </node>
                         </node>
                         <node concept="Xl_RD" id="3p40HKhESRQ" role="3uHU7w">
@@ -1482,13 +1486,16 @@
                         <node concept="Xl_RD" id="3p40HKhBJNv" role="3uHU7B">
                           <property role="Xl_RC" value="elements must be of type " />
                         </node>
-                        <node concept="2OqwBi" id="3p40HKhBKVX" role="3uHU7w">
-                          <node concept="37vLTw" id="3p40HKhBKCG" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3p40HKhBz7$" resolve="arraySpec" />
+                        <node concept="2OqwBi" id="6PsRtIQdy4t" role="3uHU7w">
+                          <node concept="2OqwBi" id="3p40HKhBKVX" role="2Oq$k0">
+                            <node concept="37vLTw" id="3p40HKhBKCG" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3p40HKhBz7$" resolve="arraySpec" />
+                            </node>
+                            <node concept="3TrEf2" id="3p40HKhBMiV" role="2OqNvi">
+                              <ref role="3Tt5mk" to="c4fa:6IWRcVPT6tm" resolve="baseType" />
+                            </node>
                           </node>
-                          <node concept="3TrEf2" id="3p40HKhBMiV" role="2OqNvi">
-                            <ref role="3Tt5mk" to="c4fa:6IWRcVPT6tm" resolve="baseType" />
-                          </node>
+                          <node concept="2Iv5rx" id="6PsRtIQdy4u" role="2OqNvi" />
                         </node>
                       </node>
                       <node concept="Xl_RD" id="3p40HKhDkzL" role="3uHU7w">

--- a/languages/com.mbeddr.cpp.modules.gen/com.mbeddr.cpp.modules.gen.mpl
+++ b/languages/com.mbeddr.cpp.modules.gen/com.mbeddr.cpp.modules.gen.mpl
@@ -64,7 +64,7 @@
         <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
         <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
         <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
         <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
         <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
         <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
@@ -189,7 +189,7 @@
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:0eddeefa-c2d6-4437-bc2c-de50fd4ce470:jetbrains.mps.lang.script" version="1" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />

--- a/languages/com.mbeddr.cpp.modules.gen/com.mbeddr.cpp.modules.gen.mpl
+++ b/languages/com.mbeddr.cpp.modules.gen/com.mbeddr.cpp.modules.gen.mpl
@@ -164,7 +164,6 @@
     <language slang="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
     <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
@@ -176,6 +175,7 @@
     <language slang="l:7fa12e9c-b949-4976-b4fa-19accbc320b4:jetbrains.mps.lang.dataFlow" version="1" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
+    <language slang="l:b1ab8c10-c118-4755-bf2a-cebab35cf533:jetbrains.mps.lang.editor.tooltips" version="0" />
     <language slang="l:64d34fcd-ad02-4e73-aff8-a581124c2e30:jetbrains.mps.lang.findUsages" version="0" />
     <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="4" />
     <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="2" />
@@ -234,6 +234,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />

--- a/languages/com.mbeddr.cpp.modules.gen/com.mbeddr.cpp.modules.gen.mpl
+++ b/languages/com.mbeddr.cpp.modules.gen/com.mbeddr.cpp.modules.gen.mpl
@@ -117,6 +117,7 @@
         <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+        <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
         <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
         <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
         <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />

--- a/languages/com.mbeddr.cpp.modules.gen/models/editor.mps
+++ b/languages/com.mbeddr.cpp.modules.gen/models/editor.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
-    <use id="a0ab8c10-c118-4755-ba27-3853435cf524" name="de.itemis.mps.tooltips" version="1" />
+    <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
   <imports>
@@ -169,12 +169,6 @@
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
-    <language id="a0ab8c10-c118-4755-ba27-3853435cf524" name="de.itemis.mps.tooltips">
-      <concept id="9185659875393567715" name="de.itemis.mps.tooltips.structure.CellModel_Tooltip" flags="ng" index="1j7BWu">
-        <child id="9185659875393569181" name="anchor" index="1j7Clw" />
-        <child id="9185659875393569179" name="tooltip" index="1j7ClA" />
-      </concept>
-    </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
       <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
         <child id="5083944728298846681" name="option" index="_tjki" />
@@ -213,6 +207,13 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips">
+      <concept id="1285659875393567816" name="jetbrains.mps.lang.editor.tooltips.structure.CellModel_Tooltip" flags="ng" index="1v6uyg">
+        <property id="4804083432920625643" name="lazy" index="2oejA6" />
+        <child id="3877544518697818164" name="tooltipCell" index="wsdo6" />
+        <child id="9185659875393569181" name="visibleCell" index="1j7Clw" />
       </concept>
     </language>
   </registry>
@@ -892,75 +893,122 @@
       <node concept="PMmxH" id="52l0VUuNEPS" role="3EZMnx">
         <ref role="PMmxG" to="j4gk:52l0VUuN8lr" resolve="IStoreInRegisterComponent" />
       </node>
-      <node concept="1j7BWu" id="5LCbJRRSJdg" role="3EZMnx">
-        <node concept="pkWqt" id="3QtFodr3mZM" role="pqm2j">
-          <node concept="3clFbS" id="3QtFodr3mZN" role="2VODD2">
-            <node concept="3clFbF" id="3QtFodr3_BL" role="3cqZAp">
-              <node concept="3y3z36" id="3QtFodr3Ar0" role="3clFbG">
-                <node concept="10Nm6u" id="3QtFodr3As2" role="3uHU7w" />
-                <node concept="2OqwBi" id="3QtFodr3_IQ" role="3uHU7B">
-                  <node concept="pncrf" id="3QtFodr3_BK" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="3QtFodr3_Zk" role="2OqNvi">
-                    <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
+      <node concept="1v6uyg" id="6PsRtIQwtt7" role="3EZMnx">
+        <property role="2oejA6" value="true" />
+        <node concept="1HlG4h" id="6PsRtIQwtYm" role="wsdo6">
+          <node concept="1HfYo3" id="6PsRtIQwtYn" role="1HlULh">
+            <node concept="3TQlhw" id="6PsRtIQwtYo" role="1Hhtcw">
+              <node concept="3clFbS" id="6PsRtIQwtYp" role="2VODD2">
+                <node concept="3clFbJ" id="6PsRtIQwtYq" role="3cqZAp">
+                  <node concept="3clFbS" id="6PsRtIQwtYr" role="3clFbx">
+                    <node concept="3cpWs6" id="6PsRtIQwtYs" role="3cqZAp">
+                      <node concept="10M0yZ" id="6PsRtIQwtYt" role="3cqZAk">
+                        <ref role="3cqZAo" to="cl6c:3ieSxUOiiJY" resolve="IN_SEMANTICS" />
+                        <ref role="1PxDUh" to="cl6c:3ieSxUOiefM" resolve="ArgumentKind_Constants" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6PsRtIQwtYu" role="3clFbw">
+                    <node concept="2OqwBi" id="6PsRtIQwtYv" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6PsRtIQwtYw" role="2Oq$k0">
+                        <node concept="pncrf" id="6PsRtIQwtYx" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="6PsRtIQwtYy" role="2OqNvi">
+                          <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="6PsRtIQwtYz" role="2OqNvi">
+                        <ref role="3TsBF5" to="x27k:13p6s1wtfz6" resolve="value" />
+                      </node>
+                    </node>
+                    <node concept="21noJN" id="6PsRtIQwtY$" role="2OqNvi">
+                      <node concept="21nZrQ" id="6PsRtIQwtY_" role="21noJM">
+                        <ref role="21nZrZ" to="x27k:13p6s1wtcLa" resolve="IN" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="6PsRtIQwtYA" role="9aQIa">
+                    <node concept="3clFbS" id="6PsRtIQwtYB" role="9aQI4">
+                      <node concept="3cpWs6" id="6PsRtIQwtYC" role="3cqZAp">
+                        <node concept="10M0yZ" id="6PsRtIQwtYD" role="3cqZAk">
+                          <ref role="3cqZAo" to="cl6c:3ieSxUOij3a" resolve="OUT_SEMANTICS" />
+                          <ref role="1PxDUh" to="cl6c:3ieSxUOiefM" resolve="ArgumentKind_Constants" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="pkWqt" id="6PsRtIQwtYE" role="pqm2j">
+            <node concept="3clFbS" id="6PsRtIQwtYF" role="2VODD2">
+              <node concept="3clFbF" id="6PsRtIQwtYG" role="3cqZAp">
+                <node concept="3y3z36" id="6PsRtIQwtYH" role="3clFbG">
+                  <node concept="10Nm6u" id="6PsRtIQwtYI" role="3uHU7w" />
+                  <node concept="2OqwBi" id="6PsRtIQwtYJ" role="3uHU7B">
+                    <node concept="pncrf" id="6PsRtIQwtYK" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="6PsRtIQwtYL" role="2OqNvi">
+                      <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="1HlG4h" id="WlkN2oQGWz" role="1j7Clw">
+        <node concept="1HlG4h" id="6PsRtIQwuqN" role="1j7Clw">
           <ref role="1ERwB7" to="cl6c:L2WnbR8bP4" resolve="IArgumentLike_ActionMap" />
-          <node concept="1HfYo3" id="WlkN2oQGW_" role="1HlULh">
-            <node concept="3TQlhw" id="WlkN2oQGWB" role="1Hhtcw">
-              <node concept="3clFbS" id="WlkN2oQGWD" role="2VODD2">
-                <node concept="3clFbJ" id="L2WnbQO8ah" role="3cqZAp">
-                  <node concept="3clFbS" id="L2WnbQO8ak" role="3clFbx">
-                    <node concept="3cpWs6" id="L2WnbQOar4" role="3cqZAp">
-                      <node concept="Xl_RD" id="L2WnbQOaEd" role="3cqZAk" />
+          <node concept="1HfYo3" id="6PsRtIQwuqO" role="1HlULh">
+            <node concept="3TQlhw" id="6PsRtIQwuqP" role="1Hhtcw">
+              <node concept="3clFbS" id="6PsRtIQwuqQ" role="2VODD2">
+                <node concept="3clFbJ" id="6PsRtIQwuqR" role="3cqZAp">
+                  <node concept="3clFbS" id="6PsRtIQwuqS" role="3clFbx">
+                    <node concept="3cpWs6" id="6PsRtIQwuqT" role="3cqZAp">
+                      <node concept="Xl_RD" id="6PsRtIQwuqU" role="3cqZAk" />
                     </node>
                   </node>
-                  <node concept="3clFbC" id="L2WnbQOa4I" role="3clFbw">
-                    <node concept="2OqwBi" id="L2WnbQO8yQ" role="3uHU7B">
-                      <node concept="pncrf" id="L2WnbQO8pn" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="L2WnbQO9lA" role="2OqNvi">
+                  <node concept="3clFbC" id="6PsRtIQwuqV" role="3clFbw">
+                    <node concept="2OqwBi" id="6PsRtIQwuqW" role="3uHU7B">
+                      <node concept="pncrf" id="6PsRtIQwuqX" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="6PsRtIQwuqY" role="2OqNvi">
                         <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
                       </node>
                     </node>
-                    <node concept="10Nm6u" id="L2WnbQOabX" role="3uHU7w" />
+                    <node concept="10Nm6u" id="6PsRtIQwuqZ" role="3uHU7w" />
                   </node>
-                  <node concept="9aQIb" id="L2WnbQOb8X" role="9aQIa">
-                    <node concept="3clFbS" id="L2WnbQOb8Y" role="9aQI4">
-                      <node concept="3clFbJ" id="5W3s9eEiei8" role="3cqZAp">
-                        <node concept="3clFbS" id="5W3s9eEieib" role="3clFbx">
-                          <node concept="3cpWs6" id="5W3s9eEihyR" role="3cqZAp">
-                            <node concept="10M0yZ" id="4cUhQNk3p53" role="3cqZAk">
+                  <node concept="9aQIb" id="6PsRtIQwur0" role="9aQIa">
+                    <node concept="3clFbS" id="6PsRtIQwur1" role="9aQI4">
+                      <node concept="3clFbJ" id="6PsRtIQwur2" role="3cqZAp">
+                        <node concept="3clFbS" id="6PsRtIQwur3" role="3clFbx">
+                          <node concept="3cpWs6" id="6PsRtIQwur4" role="3cqZAp">
+                            <node concept="10M0yZ" id="6PsRtIQwur5" role="3cqZAk">
                               <ref role="1PxDUh" to="cl6c:3ieSxUOiefM" resolve="ArgumentKind_Constants" />
                               <ref role="3cqZAo" to="cl6c:4cUhQNk3ovt" resolve="IN_KEYWORD" />
                             </node>
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="5W3s9eEig1o" role="3clFbw">
-                          <node concept="2OqwBi" id="L2WnbQOdEy" role="2Oq$k0">
-                            <node concept="2OqwBi" id="5W3s9eEiewB" role="2Oq$k0">
-                              <node concept="pncrf" id="5W3s9eEienI" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="L2WnbQObVU" role="2OqNvi">
+                        <node concept="2OqwBi" id="6PsRtIQwur6" role="3clFbw">
+                          <node concept="2OqwBi" id="6PsRtIQwur7" role="2Oq$k0">
+                            <node concept="2OqwBi" id="6PsRtIQwur8" role="2Oq$k0">
+                              <node concept="pncrf" id="6PsRtIQwur9" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="6PsRtIQwura" role="2OqNvi">
                                 <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
                               </node>
                             </node>
-                            <node concept="3TrcHB" id="L2WnbQOdUI" role="2OqNvi">
+                            <node concept="3TrcHB" id="6PsRtIQwurb" role="2OqNvi">
                               <ref role="3TsBF5" to="x27k:13p6s1wtfz6" resolve="value" />
                             </node>
                           </node>
-                          <node concept="21noJN" id="13p6s1wthKf" role="2OqNvi">
-                            <node concept="21nZrQ" id="13p6s1wthKg" role="21noJM">
+                          <node concept="21noJN" id="6PsRtIQwurc" role="2OqNvi">
+                            <node concept="21nZrQ" id="6PsRtIQwurd" role="21noJM">
                               <ref role="21nZrZ" to="x27k:13p6s1wtcLa" resolve="IN" />
                             </node>
                           </node>
                         </node>
-                        <node concept="9aQIb" id="5W3s9eEilVP" role="9aQIa">
-                          <node concept="3clFbS" id="5W3s9eEilVQ" role="9aQI4">
-                            <node concept="3cpWs6" id="5W3s9eEil9R" role="3cqZAp">
-                              <node concept="10M0yZ" id="4cUhQNk3plL" role="3cqZAk">
+                        <node concept="9aQIb" id="6PsRtIQwure" role="9aQIa">
+                          <node concept="3clFbS" id="6PsRtIQwurf" role="9aQI4">
+                            <node concept="3cpWs6" id="6PsRtIQwurg" role="3cqZAp">
+                              <node concept="10M0yZ" id="6PsRtIQwurh" role="3cqZAk">
                                 <ref role="3cqZAo" to="cl6c:4cUhQNk3ovy" resolve="OUT_KEYWORD" />
                                 <ref role="1PxDUh" to="cl6c:3ieSxUOiefM" resolve="ArgumentKind_Constants" />
                               </node>
@@ -974,15 +1022,15 @@
               </node>
             </node>
           </node>
-          <node concept="1uO$qF" id="L2WnbR5TIU" role="3F10Kt">
-            <node concept="3nzxsE" id="L2WnbR5TIV" role="1uO$qD">
-              <node concept="3clFbS" id="L2WnbR5TIW" role="2VODD2">
-                <node concept="3clFbF" id="L2WnbR5UcY" role="3cqZAp">
-                  <node concept="3y3z36" id="L2WnbR5W3E" role="3clFbG">
-                    <node concept="10Nm6u" id="L2WnbR5W9J" role="3uHU7w" />
-                    <node concept="2OqwBi" id="L2WnbR5UlS" role="3uHU7B">
-                      <node concept="pncrf" id="L2WnbR5UcX" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="L2WnbR5Vt$" role="2OqNvi">
+          <node concept="1uO$qF" id="6PsRtIQwuri" role="3F10Kt">
+            <node concept="3nzxsE" id="6PsRtIQwurj" role="1uO$qD">
+              <node concept="3clFbS" id="6PsRtIQwurk" role="2VODD2">
+                <node concept="3clFbF" id="6PsRtIQwurl" role="3cqZAp">
+                  <node concept="3y3z36" id="6PsRtIQwurm" role="3clFbG">
+                    <node concept="10Nm6u" id="6PsRtIQwurn" role="3uHU7w" />
+                    <node concept="2OqwBi" id="6PsRtIQwuro" role="3uHU7B">
+                      <node concept="pncrf" id="6PsRtIQwurp" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="6PsRtIQwurq" role="2OqNvi">
                         <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
                       </node>
                     </node>
@@ -990,19 +1038,19 @@
                 </node>
               </node>
             </node>
-            <node concept="1wgc9g" id="L2WnbR5U7L" role="3XvnJa">
+            <node concept="1wgc9g" id="6PsRtIQwurr" role="3XvnJa">
               <ref role="1wgcnl" to="cl6c:L2WnbR5T0l" resolve="DEFINED" />
             </node>
           </node>
-          <node concept="1uO$qF" id="L2WnbR5WMY" role="3F10Kt">
-            <node concept="3nzxsE" id="L2WnbR5WN0" role="1uO$qD">
-              <node concept="3clFbS" id="L2WnbR5WN2" role="2VODD2">
-                <node concept="3clFbF" id="L2WnbR5Xiv" role="3cqZAp">
-                  <node concept="3clFbC" id="L2WnbR5Zh1" role="3clFbG">
-                    <node concept="10Nm6u" id="L2WnbR5Zn6" role="3uHU7w" />
-                    <node concept="2OqwBi" id="L2WnbR5Xrp" role="3uHU7B">
-                      <node concept="pncrf" id="L2WnbR5Xiu" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="L2WnbR5Yz5" role="2OqNvi">
+          <node concept="1uO$qF" id="6PsRtIQwurs" role="3F10Kt">
+            <node concept="3nzxsE" id="6PsRtIQwurt" role="1uO$qD">
+              <node concept="3clFbS" id="6PsRtIQwuru" role="2VODD2">
+                <node concept="3clFbF" id="6PsRtIQwurv" role="3cqZAp">
+                  <node concept="3clFbC" id="6PsRtIQwurw" role="3clFbG">
+                    <node concept="10Nm6u" id="6PsRtIQwurx" role="3uHU7w" />
+                    <node concept="2OqwBi" id="6PsRtIQwury" role="3uHU7B">
+                      <node concept="pncrf" id="6PsRtIQwurz" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="6PsRtIQwur$" role="2OqNvi">
                         <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
                       </node>
                     </node>
@@ -1010,66 +1058,20 @@
                 </node>
               </node>
             </node>
-            <node concept="1wgc9g" id="L2WnbR5Xdi" role="3XvnJa">
+            <node concept="1wgc9g" id="6PsRtIQwur_" role="3XvnJa">
               <ref role="1wgcnl" to="cl6c:L2WnbR5T0f" resolve="UNKNOWN" />
             </node>
           </node>
         </node>
-        <node concept="1HlG4h" id="3aBtU3jmK5C" role="1j7ClA">
-          <node concept="1HfYo3" id="3aBtU3jmK5E" role="1HlULh">
-            <node concept="3TQlhw" id="3aBtU3jmK5G" role="1Hhtcw">
-              <node concept="3clFbS" id="3aBtU3jmK5I" role="2VODD2">
-                <node concept="3clFbJ" id="3aBtU3jqBs8" role="3cqZAp">
-                  <node concept="3clFbS" id="3aBtU3jqBs9" role="3clFbx">
-                    <node concept="3cpWs6" id="3aBtU3jqBsa" role="3cqZAp">
-                      <node concept="10M0yZ" id="3ieSxUOikvt" role="3cqZAk">
-                        <ref role="1PxDUh" to="cl6c:3ieSxUOiefM" resolve="ArgumentKind_Constants" />
-                        <ref role="3cqZAo" to="cl6c:3ieSxUOiiJY" resolve="IN_SEMANTICS" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="3aBtU3jqBsc" role="3clFbw">
-                    <node concept="2OqwBi" id="3aBtU3jqBsd" role="2Oq$k0">
-                      <node concept="2OqwBi" id="3aBtU3jqBse" role="2Oq$k0">
-                        <node concept="pncrf" id="3aBtU3jqBsf" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="3aBtU3jqBsg" role="2OqNvi">
-                          <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
-                        </node>
-                      </node>
-                      <node concept="3TrcHB" id="3aBtU3jqBsh" role="2OqNvi">
-                        <ref role="3TsBF5" to="x27k:13p6s1wtfz6" resolve="value" />
-                      </node>
-                    </node>
-                    <node concept="21noJN" id="13p6s1wthKh" role="2OqNvi">
-                      <node concept="21nZrQ" id="13p6s1wthKi" role="21noJM">
-                        <ref role="21nZrZ" to="x27k:13p6s1wtcLa" resolve="IN" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="3aBtU3jqBsw" role="9aQIa">
-                    <node concept="3clFbS" id="3aBtU3jqBsx" role="9aQI4">
-                      <node concept="3cpWs6" id="3aBtU3jqPp5" role="3cqZAp">
-                        <node concept="10M0yZ" id="3ieSxUOikYL" role="3cqZAk">
-                          <ref role="3cqZAo" to="cl6c:3ieSxUOij3a" resolve="OUT_SEMANTICS" />
-                          <ref role="1PxDUh" to="cl6c:3ieSxUOiefM" resolve="ArgumentKind_Constants" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="pkWqt" id="3aBtU3jqBLn" role="pqm2j">
-            <node concept="3clFbS" id="3aBtU3jqBLo" role="2VODD2">
-              <node concept="3clFbF" id="3aBtU3jqCaC" role="3cqZAp">
-                <node concept="3y3z36" id="3aBtU3jqFPk" role="3clFbG">
-                  <node concept="10Nm6u" id="3aBtU3jqFVp" role="3uHU7w" />
-                  <node concept="2OqwBi" id="3aBtU3jqCBz" role="3uHU7B">
-                    <node concept="pncrf" id="3aBtU3jqCaB" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="3aBtU3jqFfm" role="2OqNvi">
-                      <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
-                    </node>
+        <node concept="pkWqt" id="6PsRtIQwv2T" role="pqm2j">
+          <node concept="3clFbS" id="6PsRtIQwv2U" role="2VODD2">
+            <node concept="3clFbF" id="6PsRtIQwvly" role="3cqZAp">
+              <node concept="3y3z36" id="6PsRtIQwx35" role="3clFbG">
+                <node concept="10Nm6u" id="6PsRtIQwxd4" role="3uHU7w" />
+                <node concept="2OqwBi" id="6PsRtIQwvJa" role="3uHU7B">
+                  <node concept="pncrf" id="6PsRtIQwvlx" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6PsRtIQwwxT" role="2OqNvi">
+                    <ref role="3Tt5mk" to="x27k:L2WnbQO2tQ" resolve="kind" />
                   </node>
                 </node>
               </node>

--- a/languages/com.mbeddr.cpp.modules.gen/models/textGen.mps
+++ b/languages/com.mbeddr.cpp.modules.gen/models/textGen.mps
@@ -3,7 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="b83431fe-5c8f-40bc-8a36-65e25f4dd253" name="jetbrains.mps.lang.textGen" version="-1" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
   <imports>
     <import index="yz0i" ref="r:0777b219-94ea-49d2-8175-d5f018f3e7f9(com.mbeddr.cpp.base.textGen)" />

--- a/languages/com.mbeddr.cpp.modules/com.mbeddr.cpp.modules.mpl
+++ b/languages/com.mbeddr.cpp.modules/com.mbeddr.cpp.modules.mpl
@@ -34,7 +34,6 @@
     <language slang="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
     <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
@@ -101,6 +100,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />

--- a/languages/com.mbeddr.cpp.modules/com.mbeddr.cpp.modules.mpl
+++ b/languages/com.mbeddr.cpp.modules/com.mbeddr.cpp.modules.mpl
@@ -59,7 +59,7 @@
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:0eddeefa-c2d6-4437-bc2c-de50fd4ce470:jetbrains.mps.lang.script" version="1" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />

--- a/languages/com.mbeddr.cpp.operator_overload/com.mbeddr.cpp.operator_overload.mpl
+++ b/languages/com.mbeddr.cpp.operator_overload/com.mbeddr.cpp.operator_overload.mpl
@@ -52,7 +52,7 @@
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />

--- a/languages/com.mbeddr.cpp.operator_overload/com.mbeddr.cpp.operator_overload.mpl
+++ b/languages/com.mbeddr.cpp.operator_overload/com.mbeddr.cpp.operator_overload.mpl
@@ -94,6 +94,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />

--- a/languages/com.mbeddr.cpp.templates/com.mbeddr.cpp.templates.mpl
+++ b/languages/com.mbeddr.cpp.templates/com.mbeddr.cpp.templates.mpl
@@ -56,7 +56,7 @@
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />

--- a/languages/com.mbeddr.cpp.templates/com.mbeddr.cpp.templates.mpl
+++ b/languages/com.mbeddr.cpp.templates/com.mbeddr.cpp.templates.mpl
@@ -38,7 +38,6 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
     <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
@@ -98,6 +97,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />

--- a/languages/com.mbeddr.cpp.templates/models/behavior.mps
+++ b/languages/com.mbeddr.cpp.templates/models/behavior.mps
@@ -8,7 +8,7 @@
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>

--- a/languages/com.mbeddr.cpp.templates/models/textGen.mps
+++ b/languages/com.mbeddr.cpp.templates/models/textGen.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="b83431fe-5c8f-40bc-8a36-65e25f4dd253" name="jetbrains.mps.lang.textGen" version="1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <devkit ref="fa73d85a-ac7f-447b-846c-fcdc41caa600(jetbrains.mps.devkit.aspect.textgen)" />
   </languages>
   <imports>

--- a/scripts/allScripts.xml
+++ b/scripts/allScripts.xml
@@ -54,8 +54,7 @@
   
   <path id="path.mps.ant.path">
     <pathelement location="${artifacts.mps}/lib/ant/lib/ant-mps.jar" />
-    <pathelement location="${artifacts.mps}/lib/jdom.jar" />
-    <pathelement location="${artifacts.mps}/lib/log4j.jar" />
+    <pathelement location="${artifacts.mps}/lib/util.jar" />
   </path>
   
   <target name="assemble" depends="classes, declare-mps-tasks">

--- a/tests/test.ex.com.mbeddr.cpp/test.ex.com.mbeddr.cpp.msd
+++ b/tests/test.ex.com.mbeddr.cpp/test.ex.com.mbeddr.cpp.msd
@@ -56,7 +56,7 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="5" />

--- a/tests/test.ts.com.mbeddr.cpp/test.ts.com.mbeddr.cpp.msd
+++ b/tests/test.ts.com.mbeddr.cpp/test.ts.com.mbeddr.cpp.msd
@@ -106,6 +106,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="cc7da2f6-419f-4133-a811-31fcd3295a85(jetbrains.mps.debugger.api.api)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />

--- a/tests/test.ts.com.mbeddr.cpp/test.ts.com.mbeddr.cpp.msd
+++ b/tests/test.ts.com.mbeddr.cpp/test.ts.com.mbeddr.cpp.msd
@@ -63,7 +63,7 @@
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />


### PR DESCRIPTION
Migration to 2021.2
Removed deprecated de.itemis.mps.tooltips and replaced it with jetbrains.mps.lang.editor.tooltip